### PR TITLE
Fixed bug in file processing

### DIFF
--- a/file-1730769852952.txt
+++ b/file-1730769852952.txt
@@ -1,0 +1,1 @@
+const deepClone = (obj) => { if (typeof obj !== 'object' || obj === null) return obj; const newObject = Array.isArray(obj) ? [] : {}; for (let key in obj) { newObject[key] = deepClone(obj[key]); } return newObject; };


### PR DESCRIPTION
const deepClone = (obj) => { if (typeof obj !== 'object' || obj === null) return obj; const newObject = Array.isArray(obj) ? [] : {}; for (let key in obj) { newObject[key] = deepClone(obj[key]); } return newObject; };